### PR TITLE
Validate callId before initializing SIP session

### DIFF
--- a/index.js
+++ b/index.js
@@ -216,6 +216,10 @@ fastify.post('/openai-sip', async (request, reply) => {
     const event = request.body;
     if (event?.type === 'realtime.call.incoming') {
         const callId = event.data?.id;
+        if (!callId) {
+            fastify.log.error({ event }, 'Missing callId in realtime.call.incoming event');
+            return reply.code(400).send({ ok: false, error: 'missing callId' });
+        }
         // Accept the call then attach a session using the Agents SDK
         (async () => {
             try {


### PR DESCRIPTION
## Summary
- Guard `/openai-sip` webhook against missing `callId`
- Create `RealtimeSession` only when a valid call ID is present

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run verify` *(fails: Error fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e7ec4040832aa518238ea1d5293c